### PR TITLE
.github: Add Episode Idea issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/episode-idea.yml
+++ b/.github/ISSUE_TEMPLATE/episode-idea.yml
@@ -1,0 +1,36 @@
+name: "Episode Idea"
+description: Propose a topic, a guest or use-case for a future eCHO livestream.
+title: [Episode Idea] <concise title here>"
+labels: ["episode-idea", "pending"]
+assignees: ["lizrice", "thebsdbox", "paularah"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## eCHO Episode Idea 💡
+        #### :bee: Thank you for your contribution! Please provide as much detail as possible so we can evaluate and schedule your idea for a future eCHO livestream. :bee:
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      description: Outline the topic, the guest we should invite, the feature you would like to see demoed, any useful links. Bullet points welcome.
+      placeholder: |
+        * Topic: How ClusterMesh routes service traffic across regions
+        * Guest(s): @username, @another-guest
+        * Demo: Fail-over between AWS and GCP clusters
+        * Links: docs.example.com
+      render: markdown
+
+  - type: dropdown
+    id: theme
+    attributes:
+      label: Theme
+      description: Choose the closest theme; we may adjust later.
+      multiple: true
+      options:
+        - Cilium
+        - eBPF
+        - Tetragon
+        - Other / Mixed

--- a/.github/ISSUE_TEMPLATE/episode-idea.yml
+++ b/.github/ISSUE_TEMPLATE/episode-idea.yml
@@ -1,6 +1,6 @@
 name: "Episode Idea"
 description: Propose a topic, a guest or use-case for a future eCHO livestream.
-title: [Episode Idea] <concise title here>"
+title: "[Episode Idea] <concise title here>"
 labels: ["episode-idea", "pending"]
 assignees: ["lizrice", "thebsdbox", "paularah"]
 

--- a/.github/ISSUE_TEMPLATE/guest-request.yml
+++ b/.github/ISSUE_TEMPLATE/guest-request.yml
@@ -1,14 +1,14 @@
-name: Guest Request
-description: Complete this form to request to be a guest on eCHO  
-title: eCHO - [PROJECT NAME]  
-labels: ["guest-request", "pending"]  
+name: "Guest Request"
+description: Complete this form to request to be a guest on eCHO livestream.
+title: [Guest Request] <your project name>
+labels: ["guest-request", "pending"]
 assignees: ["lizrice", "thebsdbox", "paularah"]
 
 body:
   - type: markdown
     attributes:
       value: |
-        ## eCHO Guest Invite Form
+        ## eCHO Guest Invite Form 🎤
         #### :bee: Please fill out the following information to be featured on eCHO. The stream occurs weekly on Fridays [eBPF & Cilium Community YouTube Channel](https://www.youtube.com/watch?v=dMyb54xUSL8). :bee:
 
   - type: input
@@ -76,3 +76,16 @@ body:
       label: Additional Information
       description: Please share any additional details and links you'd like us to know about your project
       placeholder: "I'd like to talk about..."
+
+  - type: dropdown
+    id: theme
+    attributes:
+      label: Theme
+      description: Choose the closest theme; we may adjust later.
+      multiple: true
+      options:
+        - Cilium
+        - eBPF
+        - Tetragon
+        - Other / Mixed
+

--- a/.github/ISSUE_TEMPLATE/guest-request.yml
+++ b/.github/ISSUE_TEMPLATE/guest-request.yml
@@ -1,6 +1,6 @@
 name: "Guest Request"
 description: Complete this form to request to be a guest on eCHO livestream.
-title: [Guest Request] <your project name>
+title: "[Guest Request] <your project name>"
 labels: ["guest-request", "pending"]
 assignees: ["lizrice", "thebsdbox", "paularah"]
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ eCHO happens live every Friday, alternating between two timeslots:
 
 ## Suggest a topic
 
-Please [open an issue](https://github.com/isovalent/eCHO/issues/new) if you have an idea for a topic we should cover or a guest we should invite.
+Please [open an issue](https://github.com/isovalent/eCHO/issues/new/choose) if you have an idea for a topic we should cover or a guest we should invite.
 
 ## Previous episodes
 


### PR DESCRIPTION
Following what has been done for Guest Request, this PR adds a new template for Episode Idea. 
It also adjusts a bit the Guest Request one and update the README to redirect to the issue chooser URL. 

Please see individuals commits.

Here are the screenshots of what it looks like:
<img width="1241" alt="Screenshot 2025-06-06 at 10 26 00" src="https://github.com/user-attachments/assets/bf6d48f6-9e4d-49bf-baf1-a2059bc49cb2" />
<img width="435" alt="Screenshot 2025-06-06 at 10 26 15" src="https://github.com/user-attachments/assets/7caaeb15-73b4-4818-9ae5-e4fef291d47f" />


